### PR TITLE
add descriptors to GNNs

### DIFF
--- a/pkasolver/chem.py
+++ b/pkasolver/chem.py
@@ -3,6 +3,22 @@ from rdkit import Chem
 from rdkit.Chem.AllChem import GetMorganFingerprintAsBitVect
 
 
+def get_nr_of_descriptors() -> int:
+    from rdkit.Chem import Descriptors
+
+    return len(Descriptors._descList)
+
+
+def get_descriptors_from_mol(mol) -> list:
+    from rdkit.Chem import Descriptors
+    from rdkit.ML.Descriptors import MoleculeDescriptors
+
+    des_list = [x[0] for x in Descriptors._descList]
+    # Calculate all descriptors (listed in des_list)
+    calculator = MoleculeDescriptors.MolecularDescriptorCalculator(des_list)
+    return np.array(calculator.CalcDescriptors(mol))
+
+
 def create_conjugate(mol, id, pka, pH=7.4):
     """Create a new molecule that is the conjugated base/acid to the input molecule."""
     mol = Chem.RWMol(mol)

--- a/pkasolver/constants.py
+++ b/pkasolver/constants.py
@@ -58,7 +58,7 @@ smarts_dict = {
     "Possible intramolecular H-bond": ["[O,N;!H0]-*~*-*=[$([C,N;R0]=O)]"],
 }
 
-node_feat_values = {
+node_feature_values = {
     "element": [
         1,
         6,
@@ -86,15 +86,12 @@ node_feat_values = {
 
 NODE_FEATURES = {
     "element": lambda atom, marvin_atom: list(
-        map(
-            lambda s: int(atom.GetAtomicNum() == s),
-            node_feat_values["element"],
-        )
+        map(lambda s: int(atom.GetAtomicNum() == s), node_feature_values["element"],)
     ),  # still missing to mark element that's not in the list
     "formal_charge": lambda atom, marvin_atom: list(
         map(
             lambda s: int(atom.GetFormalCharge() == s),
-            node_feat_values["formal_charge"],
+            node_feature_values["formal_charge"],
         )
     ),
     "is_in_ring": lambda atom, marvin_atom: atom.IsInRing(),
@@ -102,33 +99,33 @@ NODE_FEATURES = {
     "hybridization": lambda atom, marvin_atom: list(
         map(
             lambda s: int(atom.GetHybridization() == s),
-            node_feat_values["hybridization"],
+            node_feature_values["hybridization"],
         )
     ),
     "total_num_Hs": lambda atom, marvin_atom: list(
         map(
             lambda s: int(atom.GetTotalNumHs() == s),
-            node_feat_values["total_num_Hs"],
+            node_feature_values["total_num_Hs"],
         )
     ),
     "aromatic_tag": lambda atom, marvin_atom: atom.GetIsAromatic(),
     "total_valence": lambda atom, marvin_atom: list(
         map(
             lambda s: int(atom.GetTotalValence() == s),
-            node_feat_values["total_valence"],
+            node_feature_values["total_valence"],
         )
     ),
     "total_degree": lambda atom, marvin_atom: list(
         map(
             lambda s: int(atom.GetTotalDegree() == s),
-            node_feat_values["total_degree"],
+            node_feature_values["total_degree"],
         )
     ),
     "reaction_center": lambda atom, marvin_atom: atom.GetIdx() == int(marvin_atom),
     "smarts": lambda atom, marvin_atom: make_smarts_features(atom, smarts_dict),
 }
 
-edge_feat_values = {
+edge_feature_values = {
     "bond_type": [1.0, 1.5, 2.0, 3.0],
     "is_conjugated": [1],
     "rotatable": [1],
@@ -138,9 +135,22 @@ EDGE_FEATURES = {
     "bond_type": lambda bond: list(
         map(
             lambda s: int(bond.GetBondTypeAsDouble() == s),
-            edge_feat_values["bond_type"],
+            edge_feature_values["bond_type"],
         )
     ),
     "is_conjugated": lambda bond: bond.GetIsConjugated(),
     "rotatable": lambda bond: bond_smarts_query(bond, rotatable_bond),
 }
+
+
+def calculate_nr_of_features(feature_list: list):
+    i_n = 0
+    if all(elem in node_feature_values for elem in feature_list):
+        for feat in feature_list:
+            i_n += len(node_feature_values[feat])
+    elif all(elem in edge_feature_values for elem in feature_list):
+        for feat in feature_list:
+            i_n += len(edge_feature_values[feat])
+    else:
+        raise RuntimeError()
+    return i_n

--- a/pkasolver/ml_architecture.py
+++ b/pkasolver/ml_architecture.py
@@ -1,5 +1,7 @@
 import copy
 import pickle
+from torch_geometric.nn.glob.glob import global_add_pool
+from pkasolver.chem import get_nr_of_descriptors
 
 import torch
 from torch_geometric.nn.glob import attention
@@ -101,13 +103,13 @@ class AttentivePka(AttentiveFP):
 
     @staticmethod
     def _return_lin(
-        input_dim: int, nr_of_lin_layers: int, embeding_size: int,
+        input_dim: int, nr_of_lin_layers: int, embeding_size: int, out_dim: int = 1
     ):
         lins = []
         lins.append(Linear(input_dim, embeding_size))
         for _ in range(2, nr_of_lin_layers):
             lins.append(Linear(embeding_size, embeding_size))
-        lins.append(Linear(embeding_size, 1))
+        lins.append(Linear(embeding_size, out_dim))
         return ModuleList(lins)
 
 
@@ -138,13 +140,13 @@ class GATpKa(GAT):
 
     @staticmethod
     def _return_lin(
-        input_dim: int, nr_of_lin_layers: int, embeding_size: int,
+        input_dim: int, nr_of_lin_layers: int, embeding_size: int, out_dim: int = 1
     ):
         lins = []
         lins.append(Linear(input_dim, embeding_size))
         for _ in range(2, nr_of_lin_layers):
             lins.append(Linear(embeding_size, embeding_size))
-        lins.append(Linear(embeding_size, 1))
+        lins.append(Linear(embeding_size, out_dim))
         return ModuleList(lins)
 
 
@@ -175,13 +177,13 @@ class GINpKa(GIN):
 
     @staticmethod
     def _return_lin(
-        input_dim: int, nr_of_lin_layers: int, embeding_size: int,
+        input_dim: int, nr_of_lin_layers: int, embeding_size: int, out_dim: int = 1
     ):
         lins = []
         lins.append(Linear(input_dim, embeding_size))
         for _ in range(2, nr_of_lin_layers):
             lins.append(Linear(embeding_size, embeding_size))
-        lins.append(Linear(embeding_size, 1))
+        lins.append(Linear(embeding_size, out_dim))
         return ModuleList(lins)
 
 
@@ -199,13 +201,13 @@ class GCN(torch.nn.Module):
 
     @staticmethod
     def _return_lin(
-        input_dim: int, nr_of_lin_layers: int, embeding_size: int,
+        input_dim: int, nr_of_lin_layers: int, embeding_size: int, out_dim: int = 1
     ):
         lins = []
         lins.append(Linear(input_dim, embeding_size))
         for _ in range(2, nr_of_lin_layers):
             lins.append(Linear(embeding_size, embeding_size))
-        lins.append(Linear(embeding_size, 1))
+        lins.append(Linear(embeding_size, out_dim))
         return ModuleList(lins)
 
     @staticmethod
@@ -469,7 +471,7 @@ class NNConvPairArchitecture(GCN):
         hidden_channels: int,
     ):
         super().__init__()
-        hidden_channels = 16
+        hidden_channels = 32
         self.pool = attention_pooling(num_node_features)
 
         self.convs_d = GCN._return_nnconv(

--- a/pkasolver/tests/test_chem.py
+++ b/pkasolver/tests/test_chem.py
@@ -1,6 +1,13 @@
 from pkasolver.chem import create_conjugate
-from pkasolver.data import load_data
+from pkasolver.data import (
+    _generate_normalized_descriptors,
+    load_data,
+    make_features_dicts,
+    preprocess,
+)
 from rdkit import Chem
+from pkasolver.chem import get_descriptors_from_mol
+from pkasolver.data import import_sdf
 
 
 def test_conjugates():
@@ -20,3 +27,46 @@ def test_conjugates():
             mol_new.GetNumHeavyAtoms() - mol_new.GetNumAtoms(onlyExplicit=False),
         )
         assert Chem.MolToSmiles(mol_unchanged) != Chem.MolToSmiles(mol_new)
+
+
+def test_descriptors():
+    from pkasolver.chem import get_nr_of_descriptors
+    import torch.nn.functional as F
+    import torch
+
+    sdf_filepaths = load_data()
+    df = import_sdf(sdf_filepaths["Training"])
+    smiles = df["smiles"][0]
+    print(smiles)
+    m = Chem.MolFromSmiles(smiles)
+    s = get_descriptors_from_mol(m)
+    assert len(s) == 208
+    assert len(s) == get_nr_of_descriptors()
+    print(torch.tensor(s))
+    s_norm = F.normalize(torch.tensor(s), dim=0).tolist()
+    print(s_norm)
+    torch.tensor([s_norm])
+
+
+def test_descriptors_fn():
+    from pkasolver.constants import NODE_FEATURES, EDGE_FEATURES
+    import torch
+
+    ############
+    mol_idx = 0
+    ############
+    sdf_filepaths = load_data()
+    df = preprocess(sdf_filepaths["Literature"])
+
+    list_n = ["element", "formal_charge"]
+    list_e = ["bond_type", "is_conjugated"]
+
+    selected_node_features = make_features_dicts(NODE_FEATURES, list_n)
+    selected_edge_features = make_features_dicts(EDGE_FEATURES, list_e)
+    descriptors_p, descriptors_d = _generate_normalized_descriptors(
+        df,
+        selected_edge_features=selected_edge_features,
+        selected_node_features=selected_node_features,
+    )
+    print(torch.tensor(descriptors_d[0]))
+    print(descriptors_d[0])

--- a/pkasolver/tests/test_ml.py
+++ b/pkasolver/tests/test_ml.py
@@ -19,10 +19,8 @@ from pkasolver.ml_architecture import (
 import torch
 from pkasolver.constants import (
     DEVICE,
-    node_feat_values,
-    edge_feat_values,
+    calculate_nr_of_features,
 )
-from pkasolver.data import calculate_nr_of_features
 
 models = [
     ("GCNPairSingleConv", GCNPairSingleConv),
@@ -105,11 +103,6 @@ def test_train_gcn_models():
     # calculate node/edge features
     num_node_features = calculate_nr_of_features(list_n)
     num_edge_features = calculate_nr_of_features(list_e)
-
-    i_e = 0
-    for feat in list_e:
-        i_e += len(edge_feat_values[feat])
-    num_edge_features = i_e
 
     for model_name, model_class in models:
         print(model_name)


### PR DESCRIPTION


## Description
Add descriptors to GNNs if requested. Since not all descriptorsw are available for all molecules this includes enabling to filter the dataset based on some structure properties.
## Todos
  - [ ] Adding rdkit descriptors
  - [ ] enabling filtering based on atom idx

## Status
- [ ] Ready to go