### PR TITLE
Fix Python 3.12 incompatibility in versioneer.py

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,9 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
+    parser = configparser.RawConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
## Summary

`pkasolver` fails to **install or build on Python 3.12+** because `versioneer.py` uses two APIs that were removed in Python 3.12 (both had been deprecated since Python 3.2):

| Removed API | Replacement |
|-------------|-------------|
| `configparser.SafeConfigParser()` | `configparser.RawConfigParser()` |
| `parser.readfp(f)` | `parser.read_file(f)` |

The errors at build time are:
```
AttributeError: module 'configparser' has no attribute 'SafeConfigParser'
AttributeError: 'RawConfigParser' object has no attribute 'readfp'
```

## What changed

One file, two one-line substitutions in `versioneer.py`:

```diff
-    parser = configparser.SafeConfigParser()
+    parser = configparser.RawConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        parser.read_file(f)
```

Both replacements are fully API-compatible and have been available since Python 3.2, so this patch does not affect older Python versions.

## Why it matters

Python 3.12 is now the default on many platforms (macOS Homebrew, recent Ubuntu, etc.). Without this fix, users on Python 3.12 cannot `pip install` pkasolver at all — the build step errors out before any package code runs. This is a one-line versioneer maintenance fix with zero functional impact on the library itself.

## Test plan

- [x] `pip install .` succeeds on Python 3.12
- [x] `import pkasolver` works after install
- [x] pKa predictions return expected values (tested against literature values for common aliphatic amines)